### PR TITLE
Update Heartbeat to PostSimulation

### DIFF
--- a/libraries_plus_plus/scheduler/wait.lua
+++ b/libraries_plus_plus/scheduler/wait.lua
@@ -6,7 +6,7 @@ local function wait(num: number): number
     local dt = 0
 
     while dt < num do
-        dt += RunService.Heartbeat:Wait()
+        dt += RunService.PostSimulation:Wait()
     end
     return dt
 end


### PR DESCRIPTION
Roblox has recently deprecated `RunService.Heartbeat` as part of some API renaming, and this pull request simply changes the event from `Heartbeat` to `PostSimulation`. The new events aren't live yet, so I am leaving this open until they are live to then merge it in.